### PR TITLE
Upgrade project to be compatible with Tensorflow 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pretrained_model = VGGFace(model='resnet50', include_top=True, input_shape=(224,
 ```
 ### Recommened Libraries: 
 
-Tensorflow>=1.15.3
+Tensorflow>=2.0.0
 
 ### Future
 weights from quantisation aware training will be uploaded by me in time.

--- a/keras_vggface_TF/modelsTF.py
+++ b/keras_vggface_TF/modelsTF.py
@@ -13,7 +13,6 @@ import tensorflow as tf
 from tensorflow.keras.layers import Flatten, Dense, Input, GlobalAveragePooling2D, \
     GlobalMaxPooling2D, Activation, Conv2D, MaxPooling2D, BatchNormalization, \
     AveragePooling2D, Reshape, Permute, multiply
-from tensorflow.keras.utils import convert_all_kernels_in_model
 from tensorflow.keras.utils import get_file
 from tensorflow.keras import backend as K
 from keras_vggface_TF import utils
@@ -117,8 +116,6 @@ def VGG16(include_top=True, weights='vggface',
                                     utils.VGG16_WEIGHTS_PATH_NO_TOP,
                                     cache_subdir=utils.VGGFACE_DIR)
         model.load_weights(weights_path, by_name=True)
-        if K.backend() == 'theano':
-            convert_all_kernels_in_model(model)
 
         if K.image_data_format() == 'channels_first':
             if include_top:
@@ -281,14 +278,6 @@ def RESNET50(include_top=True, weights='vggface',
                                     utils.RESNET50_WEIGHTS_PATH_NO_TOP,
                                     cache_subdir=utils.VGGFACE_DIR)
         model.load_weights(weights_path)
-        if K.backend() == 'theano':
-            layer_utils.convert_all_kernels_in_model(model)
-            if include_top:
-                maxpool = model.get_layer(name='avg_pool')
-                shape = maxpool.output_shape[1:]
-                dense = model.get_layer(name='classifier')
-                layer_utils.convert_dense_weights_data_format(dense, shape,
-                                                              'channels_first')
 
         if K.image_data_format() == 'channels_first' and K.backend() == 'tensorflow':
             warnings.warn('You are using the TensorFlow backend, yet you '
@@ -488,14 +477,6 @@ def SENET50(include_top=True, weights='vggface',
                                     utils.SENET50_WEIGHTS_PATH_NO_TOP,
                                     cache_subdir=utils.VGGFACE_DIR)
         model.load_weights(weights_path)
-        if K.backend() == 'theano':
-            layer_utils.convert_all_kernels_in_model(model)
-            if include_top:
-                maxpool = model.get_layer(name='avg_pool')
-                shape = maxpool.output_shape[1:]
-                dense = model.get_layer(name='classifier')
-                layer_utils.convert_dense_weights_data_format(dense, shape,
-                                                              'channels_first')
 
         if K.image_data_format() == 'channels_first' and K.backend() == 'tensorflow':
             warnings.warn('You are using the TensorFlow backend, yet you '

--- a/keras_vggface_TF/vggfaceTF.py
+++ b/keras_vggface_TF/vggfaceTF.py
@@ -18,12 +18,9 @@ def VGGFace(include_top=True, model='vgg16', weights='vggface',
     Optionally loads weights pre-trained
     on VGGFace datasets. Note that when using TensorFlow,
     for best performance you should set
-    `image_data_format="channels_last"` in your Keras config
-    at ~/.keras/keras.json.
-    The model and the weights are compatible with both
-    TensorFlow and Theano. The data format
-    convention used by the model is the one
-    specified in your Keras config file.
+    `image_data_format="channels_last"` (tensorflow default) as the
+    data_format parameter when loading a model.
+    The model and the weights are compatible with TensorFlow only.
     # Arguments
         include_top: whether to include the 3 fully-connected
             layers at the top of the network.


### PR DESCRIPTION
Upgrade project to make it compatible with Tensorflow 2.x. Remove Theano compatibility and conversion of all convolution kernels in a model from Theano to TensorFlow through convert_all_kernels_in_model since this method has been removed from recent versions of Tensorflow.